### PR TITLE
ENH: Optional documents for internal Project coordination

### DIFF
--- a/org-docs/PROJECT-CHARTER.md
+++ b/org-docs/PROJECT-CHARTER.md
@@ -81,6 +81,8 @@ Principal investigators will inform Maintainers about any existing commitments w
 In case of conflict between the Maintainers' criteria and the Principal investigators' proposal, an appeal must be addressed to the Organization Steering Committee.
 The Project may maintain a `.maint/ROADMAP.md` stating how roadmaps are built, how issues are prioritized and organized, and the how the release process and achievement of deliverables and milestones are monitored.
 
+These guiding principles may be made more explicit on the `.maint/HOW_WE_WORK.md` file.
+
 ## 4. Release process and Scientific publication.
 
 ### 4.1. Releases

--- a/project-docs/.maint/HOW_WE_WORK.md
+++ b/project-docs/.maint/HOW_WE_WORK.md
@@ -1,0 +1,54 @@
+# How we work
+
+This document can be used by the Project to define the Maintainers' operation workflows.
+The document is completely optional, and it is a responsibility of the Maintainers to decide whether it is used, and if so, to keep it up-to-date.
+
+<!--
+Therefore, this is the entry point where Contributors will find information about:
+* How to propose new features, changes to the code, changes to the documentation, etc., and what are the available paths to those activities depending on the estimated magnitude of the proposal (e.g., whether the project will have explicit Extension Proposal documents for major modifications).
+* Whether the Project will make use of the GitHub Projects features, how new issues are triaged into milestones and projects, how issues are prioritized and labeled (e.g., whether the project adheres to the `impact:<low|medium|high>` and `effort:<low|medium|high>` labeling system).
+* Establishing Maintainers roles, and making sure the `MAINTAINERS.md` file defines these roles and they are up-to-date in the Maintainers table.
+* Open public meetings, and their frequency, where interested parties can join and participate in the definition of the roadmap, milestones and deliverables.
+-->
+
+<!-- OPTIONAL CONTENTS: Please revise or remove these lines -->
+## Maintainers roles
+
+The Project has designated three specific roles that Maintainers will cover:
+
+* **(i)** *Lead-developer (LD)*.
+  The LD is responsible for ensuring the fluent communication between the Maintainers, keeps track of acquired responsibilities (e.g., review a pull-request), and anticipates and preempts roadblocks and conflicts that may make the work of other Maintainers harder;
+* **(ii)** *SCRUM Guider (SG)*.
+  The SG is responsible for the triage of new issues, for communicating with the Maintainers and prioritize issues and features, and coordinate the concerted effort of Maintainers.
+  The SG may also lead meetings and keeps up-to-date the GitHub Project panel and the Milestones of this Project.
+* **(iii)** *Outbound Coordinator (OC)*.
+  The OC is responsible for communicating with the maintainers of other projects (the project's OC, if the role is assigned) in the organization, ensuring that potential conflicts or incompatibility between releases across projects are resolved.
+
+## Project management
+
+The Project uses the following management tools:
+
+* **GitHub Milestones**
+* **GitHub Project panel** -- which is located at https://github.com/orgs/nipreps/projects/3
+
+**Maintainers' Meetings**.
+The maintainers will meet at least once every fours weeks (monthly), although the LD may call for extra meetings when they might be necessary.
+The agenda of the regular monthly meeting will be organized by the SG, who will also lead regular meetings.
+
+**Open Meetings**.
+Other meetings open to broader public can be proposed by any Maintainer, and the LD will be responsible of its organization in collaboration with the proponent(s).
+As for any other decision, all Maintainers must agree on calling for a meeting.
+These meetings can be organized to:
+
+* brainstorm and engage the community in developing/updating the roadmap;
+* gather feedback (e.g., after a recent new release);
+* inform about changes in the Maintainers team, as well as recruiting new members;
+* disseminate new important features;
+* make announcements; etc.
+
+## Setting priorities and triaging issues
+
+This Project follows [the general recommendations of *NiPreps*](https://www.nipreps.org/community/CONTRIBUTING/#issue-labels).
+
+<!-- OPTIONAL CONTENTS end here -->
+

--- a/project-docs/.maint/MAINTAINERS.md
+++ b/project-docs/.maint/MAINTAINERS.md
@@ -7,9 +7,9 @@ If you are participating because of your affiliation with another organization (
 
 <!-- EXAMPLE: The current contents of the table are given for an example, please update. -->
 
-| **Lastname** | **Name** | **Handle** | **ORCID** | **Affiliation** |
-| --- | --- | --- | --- | --- |
-| Jane | Doe | | | University Of Los Angeles |
-| AlFulaniyyah | Fulanah | | | Ahaggar Univeristy, Tamanrasset |
-| Mustermann | Max | | | Technische Universität Weitfortistan |
-| Hua | Li | | Chan Tai Man University |
+| **Lastname** | **Name** | **Handle** | **ORCID** | **Affiliation** | **Role** |
+| --- | --- | --- | --- | --- | --- |
+| Jane | Doe | | | University Of Los Angeles | SG |
+| AlFulaniyyah | Fulanah | | | Ahaggar Univeristy, Tamanrasset | LD, OC |
+| Mustermann | Max | | | Technische Universität Weitfortistan |  |
+| Hua | Li | | Chan Tai Man University | |


### PR DESCRIPTION
Replaces #3, which we accidentally deleted with a force push.


This PR puts together some thoughts about the Scrum master (or guider, as @ericearl suggested as a better option to master) and other organizational details of individual projects in the organization.

All the new stuff is optional.