### PR TITLE
FIX: link to non-raw project charter doc

### DIFF
--- a/project-docs/GOVERNANCE.md
+++ b/project-docs/GOVERNANCE.md
@@ -1,3 +1,3 @@
 # Governance
 
-This project belongs to the *NiPreps* Community, and its governance model abides by the [`PROJECT-CHARTER.md`](https://github.com/nipreps/GOVERNANCE/blob/main/org-docs/PROJECT-CHARTER.md) document.
+This Project belongs to the *NiPreps* Community, and its governance model abides by the [`PROJECT-CHARTER.md`](https://github.com/nipreps/GOVERNANCE/blob/main/org-docs/PROJECT-CHARTER.md) document.

--- a/project-docs/GOVERNANCE.md
+++ b/project-docs/GOVERNANCE.md
@@ -1,3 +1,3 @@
 # Governance
 
-This Project belongs to the [*NiPreps* Community, and its governance model abides by the `PROJECT-CHARTER.md` document](https://raw.githubusercontent.com/nipreps/GOVERNANCE/main/org-docs/PROJECT-CHARTER.md).
+This project belongs to the *NiPreps* Community, and its governance model abides by the [`PROJECT-CHARTER.md`](https://github.com/nipreps/GOVERNANCE/blob/main/org-docs/PROJECT-CHARTER.md) document.


### PR DESCRIPTION
The previous link destination was directed to the raw markdown page. It would be more useful to link to the rendered GitHub page.