### PR TITLE
FIX: Fixed title-case in 4

### DIFF
--- a/org-docs/PROJECT-CHARTER.md
+++ b/org-docs/PROJECT-CHARTER.md
@@ -86,7 +86,7 @@ The Project may maintain a `.maint/ROADMAP.md` stating how roadmaps are built, h
 
 These guiding principles may be made more explicit on the `.maint/HOW_WE_WORK.md` file.
 
-## 4. Release process and Scientific publication.
+## 4. Release Process and Scientific Publication.
 
 ### 4.1. Releases
 


### PR DESCRIPTION
Title-casing should be uniform within and between headings of the same level. This changes 4 to conform with title-casing for level 2 headers dictated in 3. 